### PR TITLE
Remove windows dependency on ssh-keygen and add docs on OS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ bin/kssh user@production-server-ip      # If in {TEAM}.ssh.production
 bin/kssh root@server                    # If in {TEAM}.ssh.root_everywhere
 ```
 
+# OS Support
+
+It is recommended to run the server component of this bot on linux and running it in other environments is untested. 
+`kssh` is tested and works correctly on linux, macOS, and Windows. If running on windows, note that there is a dependency
+on the `ssh` binary being in the path. This can be installed in a number of different ways including 
+[Chocolatey](https://chocolatey.org/packages/openssh) or the 
+[built in version](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse) on 
+modern versions of windows. 
+
 # Getting Started (local environment)
 ###### Recommended only for development work
 In all of these directions, replace `{USER}` with your username and `{TEAM}` with the name of the team that you wish to 

--- a/keybaseca/sshutils/generate_unix.go
+++ b/keybaseca/sshutils/generate_unix.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package sshutils
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// Generate a new SSH key. Places the private key at filename and the public key at filename.pub. If `overwrite`,
+// it will overwrite the existing key. If `printPubKey` it will print out the generated public key to stdout.
+// On unix, we use ed25519 keys since they may be more secure (and are smaller).
+func generateNewSSHKey(filename string) error {
+	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", filename, "-m", "PEM", "-N", "")
+	bytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ssh-keygen failed: %s (%v)", string(bytes), err)
+	}
+	return nil
+}

--- a/keybaseca/sshutils/generate_windows.go
+++ b/keybaseca/sshutils/generate_windows.go
@@ -1,0 +1,44 @@
+// +build windows
+// If you edit this file, be sure to test it on windows also. Our current test suite does not test windows support.
+
+package sshutils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+
+	"github.com/keybase/bot-ssh-ca/shared"
+	"golang.org/x/crypto/ssh"
+)
+
+// Generate a new SSH key. Places the private key at filename and the public key at filename.pub. If `overwrite`,
+// it will overwrite the existing key. If `printPubKey` it will print out the generated public key to stdout.
+// On windows, we use 2048 bit rsa keys. go's ssh library doesn't support ed25519 and ssh-keygen isn't built in.
+func generateNewSSHKey(filename string) error {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	privateKeyFile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer privateKeyFile.Close()
+
+	privateKeyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+	err = pem.Encode(privateKeyFile, privateKeyPEM)
+	if err != nil {
+		return err
+	}
+
+	pub, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(shared.KeyPathToPubKey(filename), ssh.MarshalAuthorizedKey(pub), 0600)
+}

--- a/keybaseca/sshutils/sshutils.go
+++ b/keybaseca/sshutils/sshutils.go
@@ -13,10 +13,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// Generate a new SSH key. Places the private key at filename and the public key at filename.pub. If `overwrite`,
-// it will overwrite the existing key. If `printPubKey` it will print out the generated public key to stdout.
 func GenerateNewSSHKey(filename string, overwrite bool, printPubKey bool) error {
-	if _, err := os.Stat(filename); err == nil {
+	_, err := os.Stat(filename)
+	if err == nil {
 		if overwrite {
 			err := os.Remove(filename)
 			if err != nil {
@@ -27,11 +26,11 @@ func GenerateNewSSHKey(filename string, overwrite bool, printPubKey bool) error 
 		}
 	}
 
-	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", filename, "-m", "PEM", "-N", "")
-	bytes, err := cmd.CombinedOutput()
+	err = generateNewSSHKey(filename)
 	if err != nil {
-		return fmt.Errorf("ssh-keygen failed: %s (%v)", string(bytes), err)
+		return err
 	}
+
 	if printPubKey {
 		bytes, err := ioutil.ReadFile(shared.KeyPathToPubKey(filename))
 		if err != nil {
@@ -39,6 +38,7 @@ func GenerateNewSSHKey(filename string, overwrite bool, printPubKey bool) error 
 		}
 		fmt.Printf("Generated new public key: \n%s\n", string(bytes))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
ssh-keygen is not part of the ssh package on windows, so this falls back to generating the SSH key using go's libraries if running on windows. kssh has now been tested and confirmed working on windows and thus that is now documented in the README. 