### PR TITLE
Add keybaseca sign command to sign keys manually when keybase is down

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,8 +39,9 @@ and on the client run `kssh -p 2222 user@server` and inspect the debug logs.
 ## Keybase is down
 
 If Keybase is down, the bot will not work since it relies on Keybase chat for communication. In this scenario, you can 
-manually sign SSH keys with the CA key. Place the CA private key in `~/cakey` and the CA public key in `~/cakey.pub`. 
-Then run the command:
+manually sign SSH keys with the CA key. This can be done via `keybaseca sign --public-key /path/to/key.pub`. Alternatively,
+this can be done manually without relying on any of the tooling in this repository. To do so, place the CA private key 
+in `~/cakey` and the CA public key in `~/cakey.pub`. Then run the command:
 
 ```bash
 ssh-keygen \
@@ -55,7 +56,7 @@ ssh-keygen \
   # Specify the password on the CA key (if exported via `keybaseca backup` there is no password)
   -N "" \
   # The location of the public key you wish to sign
-  ~/.ssh/id_rsa.pub
+  /path/to/key.pub
 ```
 
-You can then use the signed SSH key to SSH via `ssh -i ~/.ssh/id_rsa user@server`. 
+You can then use the signed SSH key to SSH via `ssh -i /path/to/key.pub user@server`. 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/keybase/go-keybase-chat-bot v0.0.0-20190812134859-bc54fd9cf83b
 	github.com/stretchr/testify v1.3.0
-	github.com/urfave/cli v1.20.0
+	github.com/urfave/cli v1.21.0
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,8 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/keybase/go-keybase-chat-bot v0.0.0-20190730220753-8e3930228e5a h1:gZKAzUClAbcGN8rEIUkqG9vXu5g9w+qLD1gA68qOX2Y=
-github.com/keybase/go-keybase-chat-bot v0.0.0-20190730220753-8e3930228e5a/go.mod h1:vNc28YFzigVJod0j5EbuTtRIe7swx8vodh2yA4jZ2s8=
 github.com/keybase/go-keybase-chat-bot v0.0.0-20190812134859-bc54fd9cf83b h1:7Te2f9LQ/rd6XSzpntz6BaCBgglZ0uiCdv3/GdhX9VA=
 github.com/keybase/go-keybase-chat-bot v0.0.0-20190812134859-bc54fd9cf83b/go.mod h1:vNc28YFzigVJod0j5EbuTtRIe7swx8vodh2yA4jZ2s8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -11,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
-github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -23,3 +22,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/src/keybaseca/config/config.go
+++ b/src/keybaseca/config/config.go
@@ -25,7 +25,9 @@ type Config interface {
 	GetStrictLogging() bool
 }
 
-func ValidateConfig(conf EnvConfig) error {
+// Validate the given config file. If offline, do so without connecting to keybase (used in code that is meant
+// to function without any reliance on Keybase).
+func ValidateConfig(conf EnvConfig, offline bool) error {
 	if len(conf.GetTeams()) == 0 {
 		return fmt.Errorf("must specify at least one team via the TEAMS environment variable")
 	}
@@ -33,13 +35,13 @@ func ValidateConfig(conf EnvConfig) error {
 		// Only a basic check for this since ssh will error out later on if it is bogus
 		return fmt.Errorf("KEY_EXPIRATION must be of the form `+<number><unit> where unit is one of `m`, `h`, `d`, `w`. Eg `+1h`. ")
 	}
-	if conf.GetLogLocation() != "" {
+	if conf.GetLogLocation() != "" && !offline {
 		err := validatePath(conf.GetLogLocation())
 		if err != nil {
 			return fmt.Errorf("LOG_LOCATION '%s' is not a valid path: %v", conf.GetLogLocation(), err)
 		}
 	}
-	if conf.getChatChannel() != "" {
+	if conf.getChatChannel() != "" && !offline {
 		team, channel, err := splitTeamChannel(conf.getChatChannel())
 		if err != nil {
 			return fmt.Errorf("Failed to parse CHAT_CHANNEL=%s: %v", conf.getChatChannel(), err)

--- a/src/keybaseca/log/log.go
+++ b/src/keybaseca/log/log.go
@@ -16,7 +16,7 @@ func Log(conf config.Config, str string) {
 	strWithTs := fmt.Sprintf("[%s] %s", time.Now().String(), str)
 
 	if conf.GetLogLocation() == "" {
-		fmt.Print(strWithTs)
+		fmt.Print(strWithTs + "\n")
 	} else {
 		err := appendToFile(conf.GetLogLocation(), strWithTs)
 		if err != nil {

--- a/src/keybaseca/sshutils/generate_unix.go
+++ b/src/keybaseca/sshutils/generate_unix.go
@@ -5,6 +5,7 @@ package sshutils
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // Generate a new SSH key. Places the private key at filename and the public key at filename.pub. If `overwrite`,
@@ -15,7 +16,7 @@ func generateNewSSHKey(filename string) error {
 	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", filename, "-m", "PEM", "-N", "")
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("ssh-keygen failed: %s (%v)", string(bytes), err)
+		return fmt.Errorf("ssh-keygen failed: %s (%v)", strings.TrimSpace(string(bytes)), err)
 	}
 	return nil
 }

--- a/src/kssh/ssh.go
+++ b/src/kssh/ssh.go
@@ -3,13 +3,14 @@ package kssh
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 func AddKeyToSSHAgent(keyPath string) error {
 	cmd := exec.Command("ssh-add", keyPath)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to add SSH key to the ssh-agent (is it running?): %s (%v)", string(bytes), err)
+		return fmt.Errorf("failed to add SSH key to the ssh-agent (is it running?): %s (%v)", strings.TrimSpace(string(bytes)), err)
 	}
 	return nil
 }

--- a/src/shared/kbfs.go
+++ b/src/shared/kbfs.go
@@ -43,7 +43,7 @@ func KBFSFileExists(kbfsFilename string) (bool, error) {
 	if strings.Contains(string(bytes), "ERROR file does not exist") {
 		return false, nil
 	}
-	return false, fmt.Errorf("failed to stat %s: %s (%v)", kbfsFilename, string(bytes), err)
+	return false, fmt.Errorf("failed to stat %s: %s (%v)", kbfsFilename, strings.TrimSpace(string(bytes)), err)
 }
 
 func KBFSRead(kbfsFilename string) ([]byte, error) {
@@ -54,7 +54,7 @@ func KBFSRead(kbfsFilename string) ([]byte, error) {
 	cmd := exec.Command("keybase", "fs", "read", kbfsFilename)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %s: %s (%v)", kbfsFilename, string(bytes), err)
+		return nil, fmt.Errorf("failed to read %s: %s (%v)", kbfsFilename, strings.TrimSpace(string(bytes)), err)
 	}
 	return bytes, nil
 }
@@ -63,7 +63,7 @@ func KBFSDelete(filename string) error {
 	cmd := exec.Command("keybase", "fs", "rm", filename)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to delete the file at %s: %s (%v)", filename, string(bytes), err)
+		return fmt.Errorf("failed to delete the file at %s: %s (%v)", filename, strings.TrimSpace(string(bytes)), err)
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func KBFSWrite(filename string, contents string, appendToFile bool) error {
 	cmd.Stdin = strings.NewReader(string(contents))
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to write to file at %s: %s (%v)", filename, string(bytes), err)
+		return fmt.Errorf("failed to write to file at %s: %s (%v)", filename, strings.TrimSpace(string(bytes)), err)
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func KBFSList(path string) ([]string, error) {
 	cmd := exec.Command("keybase", "fs", "ls", "-1", "--nocolor", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list files in /keybase/team/: %s (%v)", string(output), err)
+		return nil, fmt.Errorf("failed to list files in /keybase/team/: %s (%v)", strings.TrimSpace(string(output)), err)
 	}
 	var ret []string
 	for _, s := range strings.Split(string(output), "\n") {

--- a/src/shared/utils.go
+++ b/src/shared/utils.go
@@ -14,6 +14,10 @@ func KeyPathToCert(keyPath string) string {
 	return keyPath + "-cert.pub"
 }
 
+func PubKeyPathToKeyPath(pubKeyPath string) string {
+	return strings.Replace(pubKeyPath, ".pub", "", 1)
+}
+
 // Expand out a path that starts with a tilde to be an absolute path
 func ExpandPathWithTilde(path string) string {
 	usr, _ := user.Current()

--- a/tests/bot-entrypoint.py
+++ b/tests/bot-entrypoint.py
@@ -24,11 +24,14 @@ def load_env():
         "bin/keybaseca --wipe-all-configs\n"
         "bin/keybaseca --wipe-logs || true\n"
         "bin/keybaseca generate --overwrite-existing-key\n"
+        # The output from this backup is tested in test_env_1.py
         "echo yes | bin/keybaseca backup > /mnt/cakey.backup\n"
+        # The output from this sign operation is tested in test_env_1.py
+        "ssh-keygen -t ed25519 -f /mnt/userkey -N '' && bin/keybaseca sign --public-key /mnt/userkey.pub > /mnt/keybaseca-sign.out\n"
         "bin/keybaseca service &"
     ) % (shlex.quote(path)))
     # Sleep so keybaseca has time to start
-    time.sleep(3)
+    time.sleep(5)
     return "OK"
 
 if __name__ == '__main__':

--- a/tests/bot-entrypoint.py
+++ b/tests/bot-entrypoint.py
@@ -25,9 +25,9 @@ def load_env():
         "bin/keybaseca --wipe-logs || true\n"
         "bin/keybaseca generate --overwrite-existing-key\n"
         # The output from this backup is tested in test_env_1.py
-        "echo yes | bin/keybaseca backup > /mnt/cakey.backup\n"
+        "echo yes | bin/keybaseca backup > /shared/cakey.backup\n"
         # The output from this sign operation is tested in test_env_1.py
-        "ssh-keygen -t ed25519 -f /mnt/userkey -N '' && bin/keybaseca sign --public-key /mnt/userkey.pub > /mnt/keybaseca-sign.out\n"
+        "ssh-keygen -t ed25519 -f /shared/userkey -N '' && bin/keybaseca sign --public-key /shared/userkey.pub > /shared/keybaseca-sign.out\n"
         "bin/keybaseca service &"
     ) % (shlex.quote(path)))
     # Sleep so keybaseca has time to start

--- a/tests/tests/test_env_1.py
+++ b/tests/tests/test_env_1.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from lib import TestConfig, load_env, outputs_audit_log, assert_contains_hash, run_command, simulate_two_teams
+from lib import TestConfig, load_env, outputs_audit_log, assert_contains_hash, run_command, simulate_two_teams, get_principals
 
 test_env_1_log_filename = f"/keybase/team/{TestConfig.getDefaultTestConfig().subteam}.ssh.staging/ca.log"
 class TestMultiTeamStrictLogging:
@@ -71,6 +71,7 @@ class TestMultiTeamStrictLogging:
             """)
             assert_contains_hash(test_config.expected_hash, output)
             assert hashlib.sha1(b"foo").hexdigest().encode('utf-8') in output
+        assert get_principals("~/.ssh/keybase-signed-key---cert.pub") == set([test_config.subteam + ".ssh.staging", test_config.subteam + ".ssh.root_everywhere"])
 
     def test_kssh_errors_on_two_bots(self, test_config):
         # Test that kssh does not run if there are multiple bots, no kssh config, and no --bot flag
@@ -110,7 +111,7 @@ class TestMultiTeamStrictLogging:
             except subprocess.CalledProcessError as e:
                 assert b"Found 2 config files" in e.output
 
-    def test_keybaseca_backup(self, test_config):
+    def test_keybaseca_backup(self):
         # Test the keybaseca backup command by reading and verifying the private key stored in /mnt/cakey.backup
         run_command("mkdir -p /tmp/ssh/")
         run_command("chown -R keybase:keybase /tmp/ssh/")
@@ -131,3 +132,17 @@ class TestMultiTeamStrictLogging:
         run_command("chmod 0600 /tmp/ssh/cakey")
         output = run_command("ssh-keygen -y -e -f /tmp/ssh/cakey")
         assert b"BEGIN SSH2 PUBLIC KEY" in output
+
+    def test_keybaseca_sign(self, test_config):
+        # Stdout contains a useful message
+        with open('/mnt/keybaseca-sign.out') as f:
+            assert "Provisioned new certificate" in f.read()
+
+        # SSH with that certificate should just work for every team
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey user@sshd-prod 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey root@sshd-prod 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey user@sshd-staging 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey root@sshd-prod 'sha1sum /etc/unique'"))
+
+        # Checking that it actually contains the correct principals
+        assert get_principals("/mnt/userkey-cert.pub") == set(test_config.subteams)

--- a/tests/tests/test_env_1.py
+++ b/tests/tests/test_env_1.py
@@ -135,14 +135,14 @@ class TestMultiTeamStrictLogging:
 
     def test_keybaseca_sign(self, test_config):
         # Stdout contains a useful message
-        with open('/mnt/keybaseca-sign.out') as f:
+        with open('/shared/keybaseca-sign.out') as f:
             assert "Provisioned new certificate" in f.read()
 
         # SSH with that certificate should just work for every team
-        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey user@sshd-prod 'sha1sum /etc/unique'"))
-        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey root@sshd-prod 'sha1sum /etc/unique'"))
-        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey user@sshd-staging 'sha1sum /etc/unique'"))
-        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /mnt/userkey root@sshd-prod 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /shared/userkey user@sshd-prod 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /shared/userkey root@sshd-prod 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /shared/userkey user@sshd-staging 'sha1sum /etc/unique'"))
+        assert_contains_hash(test_config.expected_hash, run_command(f"ssh -q -o StrictHostKeyChecking=no -i /shared/userkey root@sshd-prod 'sha1sum /etc/unique'"))
 
         # Checking that it actually contains the correct principals
-        assert get_principals("/mnt/userkey-cert.pub") == set(test_config.subteams)
+        assert get_principals("/shared/userkey-cert.pub") == set(test_config.subteams)


### PR DESCRIPTION
Also:
- Adds tests for `keybaseca sign` that verify that it generates a correct signed key
- Updates docs to explain `keybaseca sign` (and keep the docs on doing it manually via ssh-keygen in case anything ever breaks with `keybaseca sign`)
- Refactored key signing to live in a single function that is called by `keybaseca sign` and the signature request handler.
- Updates the version of urfave/cli in order to pull in a recent change that added support for making CLI flags required.
- Adds `strings.TrimSpace(...)` around the output of commands when they error and we include the command's output in an error string. This removes the new line from error messages and makes them more readable.