### PR TITLE
Add ability to set a default SSH user for kssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ client config file is how kssh determines which teams are using kssh and the nee
 channel name, the name of the bot, etc). When keybaseca stops, it deletes all of the client config files. 
 
 kssh reads the client config file in order to determine how to interact with a bot. kssh does not have any user controlled
-configuration. It does have one local config file stored in `~/.ssh/kssh.config` that is used to store the default bot
-if the kssh user has access to multiple running keybaseca bots. This config file is not meant to be manually edited and is only meant to be 
-interacted with via the `--set-default-bot` and `--clear-default-bot` flags. 
+configuration. It does have one local config file stored in `~/.ssh/kssh.config` that is used to store a few settings 
+for kssh. By default, this config file is not used. It is only created and meant to be interacted with via the 
+`--set-default-bot`, `--clear-default-bot`, `--set-default-user`, `--clear-default-user` flags. 
 
 #### Communication
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ on the `ssh` binary being in the path. This can be installed in a number of diff
 [built in version](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse) on 
 modern versions of windows. 
 
+# Using kssh with jumpboxes and bastion hosts
+
+kssh does work correctly with jumpboxes and bastion hosts as long as they are configured to trust the SSH CA. For example, 
+the command `kssh -J dev@jumpbox.example.com dev@server.internal` does work correctly. If you use an SSH config
+to manage your jumpbox configuration in a way that relies on using a specific user, it may be useful to specify a default
+user for kssh to use. For example, `kssh --set-default-user dev` will make it so that `kssh -J jumpbox.example.com server.internal`
+works correctly. 
+
 # Contributing
 
 There are two separate binaries built from the code in this repo:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ client config file is how kssh determines which teams are using kssh and the nee
 channel name, the name of the bot, etc). When keybaseca stops, it deletes all of the client config files. 
 
 kssh reads the client config file in order to determine how to interact with a bot. kssh does not have any user controlled
-configuration. It does have one local config file stored in `~/.ssh/kssh.config` that is used to store a few settings 
+configuration. It does have one local config file stored in `~/.ssh/kssh-config.json` that is used to store a few settings 
 for kssh. By default, this config file is not used. It is only created and meant to be interacted with via the 
 `--set-default-bot`, `--clear-default-bot`, `--set-default-user`, `--clear-default-user` flags. 
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,18 @@ modern versions of windows.
 
 # Using kssh with jumpboxes and bastion hosts
 
-kssh does work correctly with jumpboxes and bastion hosts as long as they are configured to trust the SSH CA. For example, 
-the command `kssh -J dev@jumpbox.example.com dev@server.internal` does work correctly. If you use an SSH config
-to manage your jumpbox configuration in a way that relies on using a specific user, it may be useful to specify a default
-user for kssh to use. For example, `kssh --set-default-user dev` will make it so that `kssh -J jumpbox.example.com server.internal`
-works correctly. 
+kssh should work correctly with jumpboxes and bastion hosts as long as they are configured to trust the SSH CA and the usernames are correct. For example:
+
+```
+kssh -J developer@jumpbox.example.com developer@server.internal
+```
+
+This can also be made easier by setting the kssh default ssh-username locally, then you won't have to specify it for each server. 
+
+```
+kssh --set-default-user developer
+kssh -J jumpbox.example.com server.internal
+```
 
 # Contributing
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,9 +60,3 @@ ssh-keygen \
 ```
 
 You can then use the signed SSH key to SSH via `ssh -i /path/to/key.pub user@server`. 
-
-## Using kssh with jumpboxes and bastion hosts
-
-kssh does work correctly with jumpboxes and bastion hosts. Eg the command `kssh -J jumpbox.example.com server.internal`
-does work correctly. If using this with an SSH config, it may be useful to use `kssh --set-default-user foo` in order
-to specify a user to use for all kssh connections. 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,3 +60,9 @@ ssh-keygen \
 ```
 
 You can then use the signed SSH key to SSH via `ssh -i /path/to/key.pub user@server`. 
+
+## Using kssh with jumpboxes and bastion hosts
+
+kssh does work correctly with jumpboxes and bastion hosts. Eg the command `kssh -J jumpbox.example.com server.internal`
+does work correctly. If using this with an SSH config, it may be useful to use `kssh --set-default-user foo` in order
+to specify a user to use for all kssh connections. 

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,4 @@ require (
 	github.com/urfave/cli v1.21.0
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/src/cmd/kssh/kssh.go
+++ b/src/cmd/kssh/kssh.go
@@ -283,10 +283,19 @@ func provisionNewKey(config kssh.ConfigFile, keyPath string) error {
 // Run SSH with the given key. Calls os.Exit and does not return.
 func runSSHWithKey(keyPath string, remainingArgs []string) {
 	// Create a config file for the default user if necessary
-	useConfig, err := kssh.CreateDefaultUserConfigFile()
+	useConfig := false
+	user, err := kssh.GetDefaultSSHUser()
 	if err != nil {
-		fmt.Printf("Failed to set default user: %v\n", err)
+		fmt.Printf("Failed to retrieve default SSH user: %v\n", err)
 		os.Exit(1)
+	}
+	if user != "" {
+		useConfig = true
+		err = kssh.CreateDefaultUserConfigFile()
+		if err != nil {
+			fmt.Printf("Failed to set default user: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Add the key to the ssh-agent in case we are doing multiple connections (eg via the `-J` flag)

--- a/src/cmd/kssh/kssh.go
+++ b/src/cmd/kssh/kssh.go
@@ -301,6 +301,7 @@ func runSSHWithKey(keyPath string, remainingArgs []string) {
 
 	argumentList := []string{"-i", keyPath, "-o", "IdentitiesOnly=yes"}
 	if useConfig {
+		warnAboutAlternateConfig(remainingArgs)
 		argumentList = append(argumentList, "-F", kssh.AlternateSSHConfigFile)
 	}
 
@@ -317,4 +318,14 @@ func runSSHWithKey(keyPath string, remainingArgs []string) {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+func warnAboutAlternateConfig(arguments []string) {
+	for _, arg := range arguments {
+		if arg == "-F" {
+			fmt.Println("Warning: kssh uses the -F argument in order to implement support for default SSH users. It " +
+				"is not supported to run kssh with a default user and the -F flag. Either do not use the -F flag or run" +
+				"`kssh --clear-default-user` to reset the default SSH user. ")
+		}
+	}
 }

--- a/src/cmd/kssh/kssh_test.go
+++ b/src/cmd/kssh/kssh_test.go
@@ -46,7 +46,7 @@ func TestIsValidCert(t *testing.T) {
 }
 
 func BenchmarkLoadConfigs(b *testing.B) {
-	os.Remove("~/.ssh/kssh.config")
+	os.Remove("~/.ssh/kssh-config.json")
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {

--- a/src/kssh/config.go
+++ b/src/kssh/config.go
@@ -113,7 +113,7 @@ type LocalConfigFile struct {
 }
 
 // Where to store the local config file. Just stash it in ~/.ssh
-var localConfigFileLocation = shared.ExpandPathWithTilde("~/.ssh/kssh.config")
+var localConfigFileLocation = shared.ExpandPathWithTilde("~/.ssh/kssh-config.json")
 
 func GetDefaultSSHUser() (string, error) {
 	lcf, err := getCurrentConfig()

--- a/src/kssh/ssh.go
+++ b/src/kssh/ssh.go
@@ -2,8 +2,11 @@ package kssh
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/keybase/bot-ssh-ca/src/shared"
 )
 
 func AddKeyToSSHAgent(keyPath string) error {
@@ -11,6 +14,58 @@ func AddKeyToSSHAgent(keyPath string) error {
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to add SSH key to the ssh-agent (is it running?): %s (%v)", strings.TrimSpace(string(bytes)), err)
+	}
+	return nil
+}
+
+var AlternateSSHConfigFile = shared.ExpandPathWithTilde("~/.ssh/kssh-config")
+
+func CreateDefaultUserConfigFile() (bool, error) {
+	user, err := GetDefaultSSHUser()
+	if err != nil {
+		return false, err
+	}
+	if user == "" {
+		return false, nil
+	}
+
+	err = MakeDotSSH()
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := os.Stat(shared.ExpandPathWithTilde("~/.ssh/config")); os.IsNotExist(err) {
+		f, err := os.OpenFile(shared.ExpandPathWithTilde("~/.ssh/config"), os.O_RDONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return false, fmt.Errorf("failed to touch ~/.ssh/config: %v", err)
+		}
+		f.Close()
+	}
+
+	config := fmt.Sprintf("# kssh config file\n"+
+		"Include config\n"+
+		"Host *\n"+
+		"  User %s\n", user)
+
+	f, err := os.OpenFile(AlternateSSHConfigFile, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	_, err = f.WriteString(config)
+	if err != nil {
+		return false, err
+	}
+	fmt.Printf("Using default ssh user %s\n", user)
+	return true, nil
+}
+
+func MakeDotSSH() error {
+	if _, err := os.Stat(shared.ExpandPathWithTilde("~/.ssh/")); os.IsNotExist(err) {
+		err = os.Mkdir(shared.ExpandPathWithTilde("~/.ssh/"), 0700)
+		if err != nil {
+			return fmt.Errorf("failed to create ~/.ssh directory: %v", err)
+		}
 	}
 	return nil
 }

--- a/src/kssh/ssh.go
+++ b/src/kssh/ssh.go
@@ -20,44 +20,45 @@ func AddKeyToSSHAgent(keyPath string) error {
 
 var AlternateSSHConfigFile = shared.ExpandPathWithTilde("~/.ssh/kssh-config")
 
-func CreateDefaultUserConfigFile() (bool, error) {
+// Create an SSH config file that inherits from the default SSH config file but sets a default SSH user
+func CreateDefaultUserConfigFile() error {
 	user, err := GetDefaultSSHUser()
 	if err != nil {
-		return false, err
+		return err
 	}
 	if user == "" {
-		return false, nil
+		return nil
 	}
 
 	err = MakeDotSSH()
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if _, err := os.Stat(shared.ExpandPathWithTilde("~/.ssh/config")); os.IsNotExist(err) {
 		f, err := os.OpenFile(shared.ExpandPathWithTilde("~/.ssh/config"), os.O_RDONLY|os.O_CREATE, 0644)
 		if err != nil {
-			return false, fmt.Errorf("failed to touch ~/.ssh/config: %v", err)
+			return fmt.Errorf("failed to touch ~/.ssh/config: %v", err)
 		}
 		f.Close()
 	}
 
-	config := fmt.Sprintf("# kssh config file\n"+
+	config := fmt.Sprintf("# kssh config file to set a default SSH user\n"+
 		"Include config\n"+
 		"Host *\n"+
 		"  User %s\n", user)
 
 	f, err := os.OpenFile(AlternateSSHConfigFile, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer f.Close()
 	_, err = f.WriteString(config)
 	if err != nil {
-		return false, err
+		return err
 	}
 	fmt.Printf("Using default ssh user %s\n", user)
-	return true, nil
+	return nil
 }
 
 func MakeDotSSH() error {

--- a/tests/tests/lib.py
+++ b/tests/tests/lib.py
@@ -91,7 +91,7 @@ def clear_keys():
 def clear_local_config():
     # Clear kssh's local config file
     try:
-        run_command("rm -rf ~/.ssh/kssh.config")
+        run_command("rm -rf ~/.ssh/kssh-config.json")
     except subprocess.CalledProcessError:
         pass
 

--- a/tests/tests/test_env_1.py
+++ b/tests/tests/test_env_1.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from lib import TestConfig, load_env, outputs_audit_log, assert_contains_hash, run_command, simulate_two_teams, get_principals
+from lib import TestConfig, load_env, outputs_audit_log, assert_contains_hash, run_command, simulate_two_teams, get_principals, run_command_with_agent
 
 test_env_1_log_filename = f"/keybase/team/{TestConfig.getDefaultTestConfig().subteam}.ssh.staging/ca.log"
 class TestMultiTeamStrictLogging:
@@ -19,23 +19,23 @@ class TestMultiTeamStrictLogging:
     def test_kssh_staging_user(self, test_config):
         # Test ksshing into staging as user
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging "sha1sum /etc/unique" """))
 
     def test_kssh_staging_root(self, test_config):
         # Test ksshing into staging as user
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-staging "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-staging "sha1sum /etc/unique" """))
 
     def test_kssh_prod_root(self, test_config):
         # Test ksshing into prod as root
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
 
     def test_kssh_reject_prod_user(self, test_config):
         # Test that we can't kssh into prod as user since we aren't in the correct team for that
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
             try:
-                run_command("""bin/kssh -o StrictHostKeyChecking=no user@sshd-prod "sha1sum /etc/unique" 2>&1 """)
+                run_command_with_agent("""bin/kssh -o StrictHostKeyChecking=no user@sshd-prod "sha1sum /etc/unique" 2>&1 """)
                 assert False
             except subprocess.CalledProcessError as e:
                 assert b"Permission denied" in e.output
@@ -44,25 +44,24 @@ class TestMultiTeamStrictLogging:
     def test_kssh_reuse(self, test_config):
         # Test that kssh reuses unexpired keys
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
             start = time.time()
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
             elapsed = time.time() - start
             assert elapsed < 0.5
 
     def test_kssh_regenerate_expired_keys(self, test_config):
         # Test that kssh reprovisions a key when the stored keys are expired
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            run_command("mv ~/tests/testFiles/expired ~/.ssh/keybase-signed-key-- && mv ~/tests/testFiles/expired.pub ~/.ssh/keybase-signed-key--.pub && mv ~/tests/testFiles/expired-cert.pub ~/.ssh/keybase-signed-key---cert.pub")
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
+            run_command_with_agent("mv ~/tests/testFiles/expired ~/.ssh/keybase-signed-key-- && mv ~/tests/testFiles/expired.pub ~/.ssh/keybase-signed-key--.pub && mv ~/tests/testFiles/expired-cert.pub ~/.ssh/keybase-signed-key---cert.pub")
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
 
     def test_kssh_provision(self, test_config):
         # Test the `kssh --provision` flag
         # we have to run all of the below commands in one run_command call so that environment variables are shared
         # so ssh-agent can work
         with outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            output = run_command("""
-            eval `ssh-agent -s`
+            output = run_command_with_agent("""
             bin/kssh --provision
             ssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique"
             echo -n foo > /tmp/foo
@@ -77,7 +76,7 @@ class TestMultiTeamStrictLogging:
         # Test that kssh does not run if there are multiple bots, no kssh config, and no --bot flag
         with simulate_two_teams(test_config), outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=0):
             try:
-                run_command("bin/kssh root@sshd-prod")
+                run_command_with_agent("bin/kssh root@sshd-prod")
                 assert False
             except subprocess.CalledProcessError as e:
                 assert b"Found 2 config files" in e.output
@@ -85,28 +84,28 @@ class TestMultiTeamStrictLogging:
     def test_kssh_bot_flag(self, test_config):
         # Test that kssh works with the --bot flag
         with simulate_two_teams(test_config), outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            assert_contains_hash(test_config.expected_hash, run_command(f"bin/kssh --bot {test_config.bot_username} -q -o StrictHostKeyChecking=no root@sshd-prod 'sha1sum /etc/unique'"))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent(f"bin/kssh --bot {test_config.bot_username} -q -o StrictHostKeyChecking=no root@sshd-prod 'sha1sum /etc/unique'"))
 
     def test_kssh_set_default_bot(self, test_config):
         # Test that kssh works with the --set-default-bot flag
         with simulate_two_teams(test_config), outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            run_command(f"bin/kssh --set-default-bot {test_config.bot_username}")
-            assert_contains_hash(test_config.expected_hash, run_command("bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod 'sha1sum /etc/unique'"))
+            run_command_with_agent(f"bin/kssh --set-default-bot {test_config.bot_username}")
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod 'sha1sum /etc/unique'"))
 
     def test_kssh_override_default_bot(self, test_config):
         # Test that the --bot flag overrides the local config file
         with simulate_two_teams(test_config), outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=1):
-            run_command(f"bin/kssh --set-default-bot otherbotname")
-            assert_contains_hash(test_config.expected_hash, run_command(f"bin/kssh --bot {test_config.bot_username} -q -o StrictHostKeyChecking=no root@sshd-prod 'sha1sum /etc/unique'"))
+            run_command_with_agent(f"bin/kssh --set-default-bot otherbotname")
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent(f"bin/kssh --bot {test_config.bot_username} -q -o StrictHostKeyChecking=no root@sshd-prod 'sha1sum /etc/unique'"))
 
     def test_kssh_clear_default_bot(self, test_config):
         # Test that kssh --clear-default-bot clears the default bot
         with simulate_two_teams(test_config), outputs_audit_log(test_config, filename=test_env_1_log_filename, expected_number=0):
-            run_command(f"bin/kssh --set-default-bot {test_config.bot_username}")
-            run_command("bin/kssh --clear-default-bot")
+            run_command_with_agent(f"bin/kssh --set-default-bot {test_config.bot_username}")
+            run_command_with_agent("bin/kssh --clear-default-bot")
             try:
                 # No default set and no bot specified so it will error out
-                run_command("bin/kssh root@sshd-prod")
+                run_command_with_agent("bin/kssh root@sshd-prod")
                 assert False
             except subprocess.CalledProcessError as e:
                 assert b"Found 2 config files" in e.output
@@ -146,3 +145,14 @@ class TestMultiTeamStrictLogging:
 
         # Checking that it actually contains the correct principals
         assert get_principals("/shared/userkey-cert.pub") == set(test_config.subteams)
+
+    def test_kssh_default_user(self, test_config):
+        # Set the default user to root
+        run_command_with_agent("bin/kssh --set-default-user root")
+        # A normal SSH connection
+        assert_contains_hash(test_config.expected_hash, run_command_with_agent("bin/kssh -q -o StrictHostKeyChecking=no sshd-prod 'sha1sum /etc/unique'"))
+        assert b"root" in run_command_with_agent("bin/kssh -q -o StrictHostKeyChecking=no sshd-prod 'whoami'")
+        # A proxy jump (relies on the ssh agent)
+        assert_contains_hash(test_config.expected_hash, run_command_with_agent("bin/kssh -q -o StrictHostKeyChecking=no -J sshd-staging sshd-prod 'sha1sum /etc/unique'"))
+        # Reset the default user
+        run_command_with_agent("bin/kssh --clear-default-user")

--- a/tests/tests/test_env_2_local_audit_log.py
+++ b/tests/tests/test_env_2_local_audit_log.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lib import TestConfig, load_env, outputs_audit_log, assert_contains_hash, run_command
+from lib import TestConfig, load_env, outputs_audit_log, assert_contains_hash, run_command_with_agent
 
 class TestEnv2LocalAuditLog:
     @pytest.fixture(autouse=True, scope='class')
@@ -14,4 +14,4 @@ class TestEnv2LocalAuditLog:
     def test_kssh(self, test_config):
         # Test ksshing into staging as user
         with outputs_audit_log(test_config, filename="/shared/ca.log", expected_number=1):
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging "sha1sum /etc/unique" """))

--- a/tests/tests/test_env_3_user_not_in_first_team.py
+++ b/tests/tests/test_env_3_user_not_in_first_team.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lib import TestConfig, load_env, outputs_audit_log, clear_keys, outputs_audit_log, assert_contains_hash, run_command
+from lib import TestConfig, load_env, outputs_audit_log, clear_keys, outputs_audit_log, assert_contains_hash, run_command_with_agent
 
 class TestEnv3UserNotInFirstTeam:
     @pytest.fixture(autouse=True, scope='class')
@@ -15,8 +15,8 @@ class TestEnv3UserNotInFirstTeam:
         # Test ksshing which tests that it is correctly finding a client config
         with outputs_audit_log(test_config, filename="/shared/ca.log", expected_number=3):
             clear_keys()
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging "sha1sum /etc/unique" """))
             clear_keys()
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-staging "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-staging "sha1sum /etc/unique" """))
             clear_keys()
-            assert_contains_hash(test_config.expected_hash, run_command("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("""bin/kssh -q -o StrictHostKeyChecking=no root@sshd-prod "sha1sum /etc/unique" """))

--- a/tests/tests/test_env_4_user_not_in_configured_teams.py
+++ b/tests/tests/test_env_4_user_not_in_configured_teams.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from lib import TestConfig, load_env, outputs_audit_log, run_command
+from lib import TestConfig, load_env, outputs_audit_log, run_command, run_command_with_agent
 
 class TestEnv4UserNotInConfiguredTeams:
     @pytest.fixture(autouse=True, scope='class')
@@ -19,7 +19,7 @@ class TestEnv4UserNotInConfiguredTeams:
         with outputs_audit_log(test_config, filename="/shared/ca.log", expected_number=0):
             for s in ['user@sshd-staging', 'root@sshd-staging', 'user@sshd-prod', 'root@sshd-prod']:
                 try:
-                    run_command(f"""bin/kssh -q -o StrictHostKeyChecking=no {s} "sha1sum /etc/unique" """)
+                    run_command_with_agent(f"""bin/kssh -q -o StrictHostKeyChecking=no {s} "sha1sum /etc/unique" """)
                     assert False
                 except subprocess.CalledProcessError as e:
                     assert b"Did not find any config files in KBFS" in e.output
@@ -32,7 +32,7 @@ class TestEnv4UserNotInConfiguredTeams:
             run_command(f"echo '{client_config}' | keybase fs write /keybase/team/{test_config.subteam}.ssh/kssh-client.config")
             for s in ['user@sshd-staging', 'root@sshd-staging', 'user@sshd-prod', 'root@sshd-prod']:
                 try:
-                    run_command(f"""bin/kssh -q -o StrictHostKeyChecking=no {s} "sha1sum /etc/unique" """)
+                    run_command_with_agent(f"""bin/kssh -q -o StrictHostKeyChecking=no {s} "sha1sum /etc/unique" """)
                     assert False
                 except subprocess.CalledProcessError as e:
                     assert b"Failed to get a signed key from the CA: timed out while waiting for a response from the CA" in e.output


### PR DESCRIPTION
This feature is useful when using jumpboxes combined with ssh configs. For example, imagine you have an SSH
config that translates to this command:

```
ssh -J jump.example.com server.internal
```

When run via kssh, you want it to use the `developer` user but when run via ssh you want it to use your
username as the user (the default when no user is specified). Prior to this change, that was not possible.
Now, kssh does two new things:

1. kssh --set-default-user
	It is now possible to set a default SSH user to use with kssh. This is implemented via an SSH config
	file that applies a User directive to all hosts. This config file then inherits from the default ssh
	config file at ~/.ssh/config. This makes it possible to set a default user without modifying the
	user's ssh config file.
2. kssh now adds to the SSH agent by default
	Now by default kssh adds to the running ssh agent. This is necessary in order for jumpboxes to work
	since they rely on ssh agent forwarding.

As part of this, I also had to tweak the tests to make all of this work properly.