### PR TITLE
Add information on how to use scp and rsync with kssh and default users

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,3 +60,42 @@ ssh-keygen \
 ```
 
 You can then use the signed SSH key to SSH via `ssh -i /path/to/key.pub user@server`. 
+
+## Default Users and kssh --provision
+
+Default users are implemented using a custom SSH config file that inherits from the default one. This means that if you
+run:
+
+```bash
+kssh --set-default-user developer
+kssh --provision
+scp foo server:~/
+```
+
+It will not use the default user. There are two ways to work around this. If you do not need the default user to be kssh
+specific (eg if kssh is your primary way of accessing certain servers), then you can simply configure this default user
+globally by adding the below lines to `~/.ssh/config`
+
+```bash
+Host *
+  User developer
+```
+
+If you do not want to do this, you can run scp with the kssh specific config file via:
+
+```bash
+scp -F ~/.ssh/kssh-config foo server:~/
+```
+
+Or analogously for rsync:
+
+```bash
+rsync -e "ssh -F $HOME/.ssh/kssh-config" foo server:~/
+```
+
+It may be useful to define aliases in your bashrc to simplify this:
+
+```bash
+alias kscp='scp -F ~/.ssh/kssh-config'
+alias krsync='rsync -e "ssh -F $HOME/.ssh/kssh-config"'
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,6 +96,6 @@ rsync -e "ssh -F $HOME/.ssh/kssh-config" foo server:~/
 It may be useful to define aliases in your bashrc to simplify this:
 
 ```bash
-alias kscp='scp -F ~/.ssh/kssh-config'
-alias krsync='rsync -e "ssh -F $HOME/.ssh/kssh-config"'
+alias kscp='kssh --provision && scp -F ~/.ssh/kssh-config'
+alias krsync='kssh --provision && rsync -e "ssh -F $HOME/.ssh/kssh-config"'
 ```

--- a/src/cmd/kssh/kssh.go
+++ b/src/cmd/kssh/kssh.go
@@ -52,12 +52,30 @@ func doAction(action Action, keyPath string, remainingArgs []string) {
 	if action == SSH {
 		runSSHWithKey(keyPath, remainingArgs)
 	} else if action == Provision {
-		err := kssh.AddKeyToSSHAgent(keyPath)
-		if err != nil {
-			fmt.Printf("%v\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("Provisioned new SSH key at %s\n", keyPath)
+		provision(keyPath)
+	}
+}
+
+func provision(keyPath string) {
+	err := kssh.AddKeyToSSHAgent(keyPath)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+		os.Exit(1)
+	}
+	user, err := kssh.GetDefaultSSHUser()
+	if err != nil {
+		fmt.Printf("Failed to retrieve default SSH user: %v\n", err)
+		os.Exit(1)
+	}
+	err = kssh.CreateDefaultUserConfigFile(keyPath)
+	if err != nil {
+		fmt.Printf("Failed to create ssh config file default user: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Provisioned new SSH key at %s\n", keyPath)
+	if user != "" {
+		fmt.Println("See docs/troubleshooting.md for information on configuring scp, rsync, etc to " +
+			"use the configured kssh default user")
 	}
 }
 


### PR DESCRIPTION
This change makes it so kssh --provision creates the kssh ssh config file (the one that specifies a default ssh user). It then warns the user if they have a default user configured that they need to see the docs on how to use scp and rsync with the default user. The docs explain the problem, how to solve it, and provide aliases to do it easily.