### PR TITLE
Use a custom keybase binary for kssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ GLOBAL OPTIONS:
    --set-default-user    Set the default SSH user to be used for kssh. Useful if you use ssh configs that do not set 
 					     a default SSH user 
    --clear-default-user  Clear the default SSH user
+   --set-keybase-binary  Run kssh with a specific keybase binary rather than resolving via $PATH 
 ```
 
 ## Architecture

--- a/src/cmd/keybaseca/keybaseca.go
+++ b/src/cmd/keybaseca/keybaseca.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/keybase/bot-ssh-ca/src/keybaseca/constants"
+
 	"github.com/google/uuid"
 
 	"github.com/keybase/bot-ssh-ca/src/keybaseca/bot"
@@ -192,7 +194,7 @@ func signAction(c *cli.Context) error {
 func mainAction(c *cli.Context) error {
 	switch {
 	case c.Bool("wipe-all-configs"):
-		teams, err := shared.KBFSList("/keybase/team/")
+		teams, err := constants.GetDefaultKBFSOperationsStruct().KBFSList("/keybase/team/")
 		if err != nil {
 			return err
 		}
@@ -206,9 +208,9 @@ func mainAction(c *cli.Context) error {
 				boundChan <- 0
 
 				filename := fmt.Sprintf("/keybase/team/%s/%s", team, shared.ConfigFilename)
-				exists, _ := shared.KBFSFileExists(filename)
+				exists, _ := constants.GetDefaultKBFSOperationsStruct().KBFSFileExists(filename)
 				if exists {
-					err = shared.KBFSDelete(filename)
+					err = constants.GetDefaultKBFSOperationsStruct().KBFSDelete(filename)
 					if err != nil {
 						fmt.Printf("%v\n", err)
 					}
@@ -227,7 +229,7 @@ func mainAction(c *cli.Context) error {
 		}
 		logLocation := conf.GetLogLocation()
 		if strings.HasPrefix(logLocation, "/keybase/") {
-			err = shared.KBFSDelete(logLocation)
+			err = constants.GetDefaultKBFSOperationsStruct().KBFSDelete(logLocation)
 			if err != nil {
 				return fmt.Errorf("Failed to delete log file at %s: %v", logLocation, err)
 			}
@@ -272,7 +274,7 @@ func writeClientConfig(conf config.Config) error {
 			return err
 		}
 
-		err = shared.KBFSWrite(filename, string(content), false)
+		err = constants.GetDefaultKBFSOperationsStruct().KBFSWrite(filename, string(content), false)
 		if err != nil {
 			return err
 		}
@@ -292,7 +294,7 @@ func deleteClientConfig(conf config.Config) error {
 
 	for _, team := range teams {
 		filename := filepath.Join("/keybase/team/", team, shared.ConfigFilename)
-		err := shared.KBFSDelete(filename)
+		err := constants.GetDefaultKBFSOperationsStruct().KBFSDelete(filename)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/kssh/kssh.go
+++ b/src/cmd/kssh/kssh.go
@@ -103,6 +103,7 @@ var cliArguments = []kssh.CLIArgument{
 	{Name: "--clear-default-user", HasArgument: false},
 	{Name: "--help", HasArgument: false},
 	{Name: "-v", HasArgument: false, Preserve: true},
+	{Name: "--set-keybase-binary", HasArgument: true},
 }
 
 func generateHelpPage() string {
@@ -127,7 +128,8 @@ GLOBAL OPTIONS:
                          is using Keybase SSH CA
    --set-default-user    Set the default SSH user to be used for kssh. Useful if you use ssh configs that do not set 
 					     a default SSH user 
-   --clear-default-user  Clear the default SSH user`)
+   --clear-default-user  Clear the default SSH user
+   --set-keybase-binary  Run kssh with a specific keybase binary rather than resolving via $PATH `)
 }
 
 type Action int
@@ -186,6 +188,15 @@ func handleArgs(args []string) (string, []string, Action, error) {
 				os.Exit(1)
 			}
 			fmt.Println("Cleared default bot, exiting...")
+			os.Exit(0)
+		}
+		if arg.Argument.Name == "--set-keybase-binary" {
+			err := kssh.SetKeybaseBinaryPath(arg.Value)
+			if err != nil {
+				fmt.Printf("Failed to set the keybase binary: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println("Set keybase binary, exiting...")
 			os.Exit(0)
 		}
 		if arg.Argument.Name == "--provision" {

--- a/src/keybaseca/config/config.go
+++ b/src/keybaseca/config/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/keybase/bot-ssh-ca/src/keybaseca/constants"
+
 	"github.com/keybase/bot-ssh-ca/src/keybaseca/botwrapper"
 
 	"github.com/keybase/bot-ssh-ca/src/shared"
@@ -89,17 +91,17 @@ func validateChannel(conf Config, teamName string, channelName string) error {
 func validatePath(path string) error {
 	if strings.HasPrefix(path, "/keybase/") {
 		// If it exists it is valid
-		exists, _ := shared.KBFSFileExists(path)
+		exists, _ := constants.GetDefaultKBFSOperationsStruct().KBFSFileExists(path)
 		if exists {
 			return nil
 		}
 
 		// Otherwise try to write to it
-		err := shared.KBFSWrite(path, "", false)
+		err := constants.GetDefaultKBFSOperationsStruct().KBFSWrite(path, "", false)
 		if err != nil {
 			return fmt.Errorf("path is not writable: %v", err)
 		}
-		shared.KBFSDelete(path)
+		constants.GetDefaultKBFSOperationsStruct().KBFSDelete(path)
 		return nil
 	}
 	_, err := os.Stat(path)

--- a/src/keybaseca/constants/kbfs.go
+++ b/src/keybaseca/constants/kbfs.go
@@ -1,0 +1,9 @@
+package constants
+
+import "github.com/keybase/bot-ssh-ca/src/shared"
+
+// Get the default KBFSOperation struct used for KBFS operations. Currently keybaseca does not support running with a
+// custom keybase binary path
+func GetDefaultKBFSOperationsStruct() *shared.KBFSOperation {
+	return &shared.KBFSOperation{KeybaseBinaryPath: "keybase"}
+}

--- a/src/keybaseca/log/log.go
+++ b/src/keybaseca/log/log.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keybase/bot-ssh-ca/src/keybaseca/constants"
+
 	"github.com/keybase/bot-ssh-ca/src/keybaseca/config"
-	"github.com/keybase/bot-ssh-ca/src/shared"
 )
 
 // Log attempts to log the given string to a file. If conf.GetStrictLogging() it will panic if it fails
@@ -33,7 +34,7 @@ func Log(conf config.Config, str string) {
 // the local filesystem
 func appendToFile(filename string, str string) error {
 	if strings.HasPrefix(filename, "/keybase/") {
-		return shared.KBFSWrite(filename, str, true)
+		return constants.GetDefaultKBFSOperationsStruct().KBFSWrite(filename, str, true)
 	}
 	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {

--- a/src/kssh/bot.go
+++ b/src/kssh/bot.go
@@ -14,7 +14,7 @@ import (
 func GetSignedKey(config ConfigFile, request shared.SignatureRequest) (shared.SignatureResponse, error) {
 	empty := shared.SignatureResponse{}
 
-	runOptions := kbchat.RunOptions{KeybaseLocation: "keybase"}
+	runOptions := kbchat.RunOptions{KeybaseLocation: GetKeybaseBinaryPath()}
 	kbc, err := kbchat.Start(runOptions)
 	if err != nil {
 		return empty, fmt.Errorf("error starting Keybase chat: %v", err)

--- a/src/kssh/config.go
+++ b/src/kssh/config.go
@@ -150,6 +150,17 @@ func GetDefaultSSHUser() (string, error) {
 }
 
 // Set the default SSH user to use for kssh connections.
+func SetKeybaseBinaryPath(path string) error {
+	lcf, err := getCurrentConfig()
+	if err != nil {
+		return err
+	}
+
+	lcf.KeybaseBinPath = path
+	return writeConfig(lcf)
+}
+
+// Set the default SSH user to use for kssh connections.
 func SetDefaultSSHUser(username string) error {
 	if strings.ContainsAny(username, " \t\n\r'\"") {
 		return fmt.Errorf("invalid username: %s", username)

--- a/src/shared/kbfs.go
+++ b/src/shared/kbfs.go
@@ -22,8 +22,12 @@ func supportsFuse() bool {
 	return err1 == nil && err2 == nil && err3 == nil && err4 == nil
 }
 
+type KBFSOperation struct {
+	KeybaseBinaryPath string
+}
+
 // Returns whether the given KBFS file exists
-func KBFSFileExists(kbfsFilename string) (bool, error) {
+func (ko *KBFSOperation) KBFSFileExists(kbfsFilename string) (bool, error) {
 	if supportsFuse() {
 		// Note that this code is not tested via integration tests since fuse does not run in docker. Handle with care.
 		_, err := os.Stat(kbfsFilename)
@@ -36,7 +40,7 @@ func KBFSFileExists(kbfsFilename string) (bool, error) {
 		return false, err
 	}
 
-	cmd := exec.Command("keybase", "fs", "stat", kbfsFilename)
+	cmd := exec.Command(ko.KeybaseBinaryPath, "fs", "stat", kbfsFilename)
 	bytes, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil
@@ -48,12 +52,12 @@ func KBFSFileExists(kbfsFilename string) (bool, error) {
 }
 
 // Reads the specified KBFS file into a byte array
-func KBFSRead(kbfsFilename string) ([]byte, error) {
+func (ko *KBFSOperation) KBFSRead(kbfsFilename string) ([]byte, error) {
 	if supportsFuse() {
 		// Note that this code is not tested via integration tests since fuse does not run in docker. Handle with care.
 		return ioutil.ReadFile(kbfsFilename)
 	}
-	cmd := exec.Command("keybase", "fs", "read", kbfsFilename)
+	cmd := exec.Command(ko.KeybaseBinaryPath, "fs", "read", kbfsFilename)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %s (%v)", kbfsFilename, strings.TrimSpace(string(bytes)), err)
@@ -62,8 +66,8 @@ func KBFSRead(kbfsFilename string) ([]byte, error) {
 }
 
 // Delete the specified KBFS file
-func KBFSDelete(filename string) error {
-	cmd := exec.Command("keybase", "fs", "rm", filename)
+func (ko *KBFSOperation) KBFSDelete(filename string) error {
+	cmd := exec.Command(ko.KeybaseBinaryPath, "fs", "rm", filename)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to delete the file at %s: %s (%v)", filename, strings.TrimSpace(string(bytes)), err)
@@ -73,20 +77,20 @@ func KBFSDelete(filename string) error {
 
 // Write contents to the specified KBFS file. If appendToFile, appends onto the end of the file. Otherwise, overwrites
 // and truncates the file.
-func KBFSWrite(filename string, contents string, appendToFile bool) error {
+func (ko *KBFSOperation) KBFSWrite(filename string, contents string, appendToFile bool) error {
 	var cmd *exec.Cmd
 	if appendToFile {
 		// `keybase fs write --append` only works if the file already exists so create it if it does not exist
-		exists, err := KBFSFileExists(filename)
+		exists, err := ko.KBFSFileExists(filename)
 		if !exists || err != nil {
-			err = KBFSWrite(filename, "", false)
+			err = ko.KBFSWrite(filename, "", false)
 			if err != nil {
 				return err
 			}
 		}
-		cmd = exec.Command("keybase", "fs", "write", "--append", filename)
+		cmd = exec.Command(ko.KeybaseBinaryPath, "fs", "write", "--append", filename)
 	} else {
-		cmd = exec.Command("keybase", "fs", "write", filename)
+		cmd = exec.Command(ko.KeybaseBinaryPath, "fs", "write", filename)
 	}
 
 	cmd.Stdin = strings.NewReader(string(contents))
@@ -98,8 +102,8 @@ func KBFSWrite(filename string, contents string, appendToFile bool) error {
 }
 
 // List KBFS files in the given KBFS path
-func KBFSList(path string) ([]string, error) {
-	cmd := exec.Command("keybase", "fs", "ls", "-1", "--nocolor", path)
+func (ko *KBFSOperation) KBFSList(path string) ([]string, error) {
+	cmd := exec.Command(ko.KeybaseBinaryPath, "fs", "ls", "-1", "--nocolor", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list files in /keybase/team/: %s (%v)", strings.TrimSpace(string(output)), err)

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -18,10 +18,13 @@ USER keybase
 # Install go
 USER root
 RUN add-apt-repository ppa:gophers/archive -y
-RUN apt-get update
-RUN apt-get install golang-1.11-go git sudo python3 python3-pip -y
+RUN apt-get update -y
+RUN apt-get install golang-1.11-go git sudo python3 python3-pip sudo -y
 RUN pip3 install pytest requests
-USER keybase
+
+# Make it so the keybase user has passwordless sudo so it can move the keybase binary around
+RUN echo "keybase ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/keybase && \
+    chmod 0440 /etc/sudoers.d/keybase
 
 # Install go dependencies (speeds up future builds)
 COPY --chown=keybase go.mod .

--- a/tests/tests/test_env_1.py
+++ b/tests/tests/test_env_1.py
@@ -156,3 +156,15 @@ class TestMultiTeamStrictLogging:
         assert_contains_hash(test_config.expected_hash, run_command_with_agent("bin/kssh -q -o StrictHostKeyChecking=no -J sshd-staging sshd-prod 'sha1sum /etc/unique'"))
         # Reset the default user
         run_command_with_agent("bin/kssh --clear-default-user")
+
+    def test_kssh_alternate_binary(self, test_config):
+        # Test it by creating another keybase binary earlier in the path and running kssh. This isn't a perfect test but it is
+        # enough to smoketest it
+        run_command("echo '#!/bin/bash' | sudo tee /usr/local/bin/keybase")
+        run_command("sudo chmod +x /usr/local/bin/keybase")
+        try:
+            run_command("bin/kssh --set-keybase-binary /usr/bin/keybase")
+            assert_contains_hash(test_config.expected_hash, run_command_with_agent("bin/kssh -q -o StrictHostKeyChecking=no user@sshd-staging 'sha1sum /etc/unique'"))
+            run_command("bin/kssh --set-keybase-binary ''")
+        finally:
+            run_command("sudo rm /usr/local/bin/keybase")


### PR DESCRIPTION
Per @mlsteele's request, this adds the ability for kssh to use a custom keybase binary via `kssh --set-keybase-binary /usr/bin/keybase`. This also includes an integration test for this functionality. 