### PR TITLE
Rename module to match github repo name: bot-sshca

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/keybase/bot-ssh-ca
+module github.com/keybase/bot-sshca
 
 go 1.12
 

--- a/src/cmd/keybaseca/keybaseca.go
+++ b/src/cmd/keybaseca/keybaseca.go
@@ -12,16 +12,16 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/constants"
+	"github.com/keybase/bot-sshca/src/keybaseca/constants"
 
 	"github.com/google/uuid"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/bot"
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/config"
-	klog "github.com/keybase/bot-ssh-ca/src/keybaseca/log"
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/sshutils"
-	"github.com/keybase/bot-ssh-ca/src/kssh"
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/keybaseca/bot"
+	"github.com/keybase/bot-sshca/src/keybaseca/config"
+	klog "github.com/keybase/bot-sshca/src/keybaseca/log"
+	"github.com/keybase/bot-sshca/src/keybaseca/sshutils"
+	"github.com/keybase/bot-sshca/src/kssh"
+	"github.com/keybase/bot-sshca/src/shared"
 
 	"github.com/urfave/cli"
 )

--- a/src/cmd/kssh/kssh.go
+++ b/src/cmd/kssh/kssh.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/sshutils"
+	"github.com/keybase/bot-sshca/src/keybaseca/sshutils"
 
 	"github.com/google/uuid"
-	"github.com/keybase/bot-ssh-ca/src/kssh"
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/kssh"
+	"github.com/keybase/bot-sshca/src/shared"
 	log "github.com/sirupsen/logrus"
 
 	"golang.org/x/crypto/ssh"

--- a/src/cmd/kssh/kssh_test.go
+++ b/src/cmd/kssh/kssh_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +26,7 @@ func copyKeyFromTestFixture(t *testing.T, name, destination string) {
 }
 
 func TestIsValidCert(t *testing.T) {
-	certTestFilename := "/tmp/bot-ssh-ca-test-is-valid-cert"
+	certTestFilename := "/tmp/bot-sshca-test-is-valid-cert"
 
 	os.Remove(certTestFilename)
 	os.Remove(shared.KeyPathToPubKey(certTestFilename))

--- a/src/keybaseca/bot/bot.go
+++ b/src/keybaseca/bot/bot.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/botwrapper"
+	"github.com/keybase/bot-sshca/src/keybaseca/botwrapper"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/log"
+	"github.com/keybase/bot-sshca/src/keybaseca/log"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/sshutils"
+	"github.com/keybase/bot-sshca/src/keybaseca/sshutils"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/config"
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/keybaseca/config"
+	"github.com/keybase/bot-sshca/src/shared"
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
 )
 

--- a/src/keybaseca/config/config.go
+++ b/src/keybaseca/config/config.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/constants"
+	"github.com/keybase/bot-sshca/src/keybaseca/constants"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/botwrapper"
+	"github.com/keybase/bot-sshca/src/keybaseca/botwrapper"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 )
 
 // Represents a loaded and validated config for keybaseca

--- a/src/keybaseca/constants/kbfs.go
+++ b/src/keybaseca/constants/kbfs.go
@@ -1,6 +1,6 @@
 package constants
 
-import "github.com/keybase/bot-ssh-ca/src/shared"
+import "github.com/keybase/bot-sshca/src/shared"
 
 // Get the default KBFSOperation struct used for KBFS operations. Currently keybaseca does not support running with a
 // custom keybase binary path

--- a/src/keybaseca/log/log.go
+++ b/src/keybaseca/log/log.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/constants"
+	"github.com/keybase/bot-sshca/src/keybaseca/constants"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/config"
+	"github.com/keybase/bot-sshca/src/keybaseca/config"
 )
 
 // Log attempts to log the given string to a file. If conf.GetStrictLogging() it will panic if it fails

--- a/src/keybaseca/sshutils/generate_test.go
+++ b/src/keybaseca/sshutils/generate_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 	"github.com/stretchr/testify/require"
 )
 
 // Test generating a new SSH key
 func TestGenerateNewSSHKey(t *testing.T) {
-	filename := "/tmp/bot-ssh-ca-integration-test-generate-key"
+	filename := "/tmp/bot-sshca-integration-test-generate-key"
 	os.Remove(filename)
 
 	err := GenerateNewSSHKey(filename, false, false)

--- a/src/keybaseca/sshutils/generate_windows.go
+++ b/src/keybaseca/sshutils/generate_windows.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/src/keybaseca/sshutils/sshutils.go
+++ b/src/keybaseca/sshutils/sshutils.go
@@ -7,12 +7,12 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/botwrapper"
+	"github.com/keybase/bot-sshca/src/keybaseca/botwrapper"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/log"
+	"github.com/keybase/bot-sshca/src/keybaseca/log"
 
-	"github.com/keybase/bot-ssh-ca/src/keybaseca/config"
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/keybaseca/config"
+	"github.com/keybase/bot-sshca/src/shared"
 
 	"github.com/google/uuid"
 )

--- a/src/kssh/bot.go
+++ b/src/kssh/bot.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
 )
 

--- a/src/kssh/config.go
+++ b/src/kssh/config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 )
 
 // A ConfigFile that is provided by the keybaseca server process and lives in kbfs. It is used to share configuration

--- a/src/kssh/ssh.go
+++ b/src/kssh/ssh.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/keybase/bot-ssh-ca/src/shared"
+	"github.com/keybase/bot-sshca/src/shared"
 )
 
 // Add the SSH key at the given location to the currently running SSH agent. Errors if there is no running ssh-agent.

--- a/src/shared/kbfs.go
+++ b/src/shared/kbfs.go
@@ -93,7 +93,7 @@ func (ko *KBFSOperation) KBFSWrite(filename string, contents string, appendToFil
 		cmd = exec.Command(ko.KeybaseBinaryPath, "fs", "write", filename)
 	}
 
-	cmd.Stdin = strings.NewReader(string(contents))
+	cmd.Stdin = strings.NewReader(contents)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to write to file at %s: %s (%v)", filename, strings.TrimSpace(string(bytes)), err)


### PR DESCRIPTION
@joshblum noticed that the name of the go module was `bot-ssh-ca` while the repo name was `bot-sshca`. This didn't cause any issues (since nothing imports this code) but is still worth fixing. Just did a global find and replace `bot-ssh-ca` --> `bot-sshca`. 

Also fix a linting error that popped up. 