### PR TITLE
Makefile update.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,51 +4,67 @@ FORCE_WRITE := $(FORCE_WRITE)
 else
 FORCE_WRITE := false
 endif
+ifdef VOLUME_NAME
+VOLUME_NAME := ${VOLUME_NAME}
+else
+VOLUME_NAME := keybase-sshca-volume
+endif
 
 SHELL := /bin/bash
 
-.PHONY: build generate serve clean reset-permissions confirm-clean env-file-exists ca-key-exists
+.PHONY: build generate serve clean confirm-clean create-volume env-file-exists ca-key-exists
 
-# Build a new docker image for the CA bot
-build: reset-permissions
+# Function to fetch containers which are using a specific docker volume.
+# In this case, the volume that is mounted to the CA.
+GET_CONTAINERS := $(shell docker ps -qa | xargs docker container inspect -f '{{ .Name }} {{ .HostConfig.Binds }}' | grep $(VOLUME_NAME) | awk '{print $$1}')
+
+# Build a new docker image for the CA bot.
+build:
 	docker build -t ca -f Dockerfile-ca ..
 
-# Generate a new CA key
-generate: env-file-exists build
-	source env.sh && docker run -e FORCE_WRITE=$(FORCE_WRITE) -e KEYBASE_USERNAME -e KEYBASE_PAPERKEY -e TEAMS -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest docker/entrypoint-generate.sh
-	@echo -e "\nRun these commands on each server that you wish to use with the CA chatbot\n"
+# Generate a new CA key.
+generate: env-file-exists build create-volume
+	source env.sh && docker run --rm -e FORCE_WRITE=$(FORCE_WRITE) -e KEYBASE_USERNAME -e KEYBASE_PAPERKEY -e TEAM -v $(VOLUME_NAME):/mnt:rw ca:latest docker/entrypoint-generate.sh
+	@echo -e "\n------------------------------------------------------------------------------------------------\n"
+	@echo -e "Run these commands on each server that you wish to use with the CA chatbot:\n"
 	@echo "useradd developer && mkdir -p /home/developer && chown developer:developer /home/developer  # The user that will be used for non-root logins"
-	@echo "echo \"`cat $(CURDIR)/example-keybaseca-volume/keybase-ca-key.pub`\" > /etc/ssh/ca.pub"
+	@echo "echo \"`docker run --rm -v $(VOLUME_NAME):/tmp ca cat /tmp/keybase-ca-key.pub`\" > /etc/ssh/ca.pub"
 	@echo "echo \"TrustedUserCAKeys /etc/ssh/ca.pub\" >> /etc/ssh/sshd_config"
 	@echo "echo \"AuthorizedPrincipalsFile /etc/ssh/auth_principals/%u\" >> /etc/ssh/sshd_config"
 	@echo "chmod g-w /etc   # On some distributions /etc is group writable which will cause SSH to refuse to run"
 	@echo "service ssh restart"
-	@echo -e "\nSee the README for information on how to define which teams are allowed to access which servers"
+	@echo -e "\nSee the README for information on how to define which teams are allowed to access which servers\n"
+	@echo "------------------------------------------------------------------------------------------------"
 
 # Start the CA chatbot in the background
 serve: env-file-exists ca-key-exists build
-	source env.sh && docker run -d --restart unless-stopped -e KEYBASE_USERNAME -e KEYBASE_PAPERKEY -e TEAMS -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest docker/entrypoint-server.sh
-	@echo "Started CA bot service in the background... Use `docker ps` and `docker logs` to monitor it"
+	source env.sh && docker run -d --restart unless-stopped -e KEYBASE_USERNAME -e KEYBASE_PAPERKEY -e TEAM -v $(VOLUME_NAME):/mnt ca:latest docker/entrypoint-server.sh
+	@echo "Started CA bot service in the background... Use 'docker ps' and 'docker logs -f <container name>' to monitor it"
 
-# Wipe all data
-clean: confirm-clean reset-permissions
-	@# Sudo since it is likely owned by another use since it was written from a docker container
-	sudo rm -rf example-keybaseca-volume/keybaseca*
-	sudo rm -rf example-keybaseca-volume/keybase-ca*
+# Wipe all data.
+# This is done by first stopping and deleting all containers that uses the volume that the certificates are stored in.
+# When the containers are gone, the volume is removed.
+clean: confirm-clean
+	@echo "Checking for running containers..."
+	@[[ -z "$(GET_CONTAINERS)" ]] || (docker stop $(GET_CONTAINERS); docker rm $(GET_CONTAINERS))
+	@docker volume ls | grep -q $(VOLUME_NAME) && (docker volume rm $(VOLUME_NAME) 2>&1 && echo "Clean done.") || echo "Already clean!"
 
-# Confirm that the user is okay with deleting their CA key
+# Confirm that the user is okay with deleting their CA key.
 confirm-clean:
 	@echo -n "Are you sure? This will delete the CA key used to connect to your servers [yes/N] " && read ans && [ $${ans:-N} = yes ]
 
-# Reset the permissions on the shared volume. Sudo since the permissions get messed up from the docker container chown-ing it
-reset-permissions:
-	# Avoid prompting for sudo unless the permissions actually need to be chnaged by piping find to xargs
-	find example-keybaseca-volume/ -not -user $$USER | xargs -I {} -- sudo chown -R $$USER {}
+# Creates a new volume to be used by the keybase ssh-ca server to store certificates in.
+# If a volume already exists, this will do nothing.
+create-volume:
+	@docker volume ls | grep -q $(VOLUME_NAME) || docker volume create $(VOLUME_NAME)
 
 # Asserts that env.sh exists
 env-file-exists:
 	@test -e "env.sh" || (echo "You must create and fill in env.sh prior to running make" && exit 1)
 
-# Assert that a CA key exists
+# Assert that a CA key exists.
+# This is done by first checking if there is a docker volume created with the name defined via $VOLUME_NAME,
+# If it exists, a check is done to see if there is a public key in the volume or not.
 ca-key-exists:
-	@test -e "example-keybaseca-volume/keybase-ca-key" || (echo "You must run make generate prior to make serve" && exit 1)
+	@docker volume ls | grep -q $(VOLUME_NAME) || (echo "You must run make generate prior to make serve" && exit 1)
+	@docker run --rm -v $(VOLUME_NAME):/tmp ca cat /tmp/keybase-ca-key.pub > /dev/null 2>&1 || (echo "You must run make generate prior to make serve" && exit 1)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+# Docker
+
+This directory contains the build script and files to create and run the SSHCA service as a docker container.  
+The container created will mount a persistent container in which the certificates will be created.  
+
+The following commands are available through the make file:
+
+`make generate`  
+This command is the first command you aught to run, it builds and creates the docker image and the certificates 
+used by the service.
+
+`make serve`  
+The serve command starts the service as a docker container.
+
+`make clean`  
+Clean will remove all running or dormant containers which are using the volume that the certificates are stored in,
+after removal, it will delete the volume so that a new one can be created.  
+
+_Observe: By running the clean command, all certificates will be deleted and you will not be able to create new ones._

--- a/docker/example-keybaseca-volume/.gitignore
+++ b/docker/example-keybaseca-volume/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!README.md

--- a/docker/example-keybaseca-volume/README.md
+++ b/docker/example-keybaseca-volume/README.md
@@ -1,1 +1,0 @@
-This directory is used with the docker instructions as an example volume used to store the CA key. Do not override the gitignore in this file in order to commit any files in this directory.


### PR DESCRIPTION
This pull request includes the following changes:

* The initial container creation in `generate` now uses a auto-removed container.
* Instead of using a local bound volume, a persistent docker volume is attached to the containers.
* `example-keybaseca-volume` was removed.
* Readme file was added to the docker folder to describe the main tasks in the make file.
* `reset-permissions` have been removed as it is no longer needed.
* `create-volume` have been introduced - it creates a new persistent volume in case one with the set name does not exist.
* `clean` now removes all containers using the volume and deletes the volume.
* Some minor changes to make the output easier to read was made.

---

**Observe!**

This PR have a breaking change. The new volume does not import earlier created certificates. If one have those, the following could be used to import them into the volume (after `generate`).

```
docker run --rm -v $(pwd)/example-keybaseca-volume:/tmp -v  keybase-sshca-volume:/mnt cp /tmp/* /mnt
```

This should copy all the files from the old example-keybase-volume into the new persistent volume.

--- 

_notice:_

I was unable to run the tests locally, so if that is possible, please let me know how to. I did run the make tasks a couple of hundred times and tried to cover each possible scenario, but that might not be enough, hehe.