### PR TITLE
Deletion of SSH Operations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,6 @@ and that the bot is responding to messages. Afterwards, a `SignatureRequest` pac
 returns a signed key. Note that only public keys and signatures are sent over Keybase chat and private keys never 
 leave the devices they were generated on. 
 
-#### SSH Operations
-
-On nix style systems (linux and MacOS), kssh generates and uses ed25519 private keys using the ssh-keygen binary. In 
-order to remove the dependency on ssh-keygen for windows systems (since it is not always installed on windows), kssh 
-will generate a 2048 bit RSA key when running on Windows. 
-
-keybaseca uses the ssh-keygen binary in order to complete all key signing operations. 
-
 #### KBFS
 
 In order to ensure that keybaseca can run inside of docker (which does not support FUSE filesystems without adding


### PR DESCRIPTION
Thanks to PR #36, the application now uses a go package to generate esdca keys instead of using the ssh-keygen program.  
This pull request removes the section of the readme stating that the ssh-keygen program is a dependency.