### PR TITLE
Remove docker prune in favor of docker-compose down + flags

### DIFF
--- a/integrationTest.sh
+++ b/integrationTest.sh
@@ -31,8 +31,7 @@ NC='\033[0m'
 indent() { sed 's/^/    /'; }
 # Reset docker and wipe all volumes
 reset_docker() {
-    docker-compose down -v
-    docker system prune -f
+    docker-compose down -v --remove-orphans --rmi local
 }
 
 cd tests/


### PR DESCRIPTION
This makes it so running the integration test will only wipe out images/volumes associated with the integration tests rather than all images/volumes. Note the flags which are necessary in order to delete the images and volumes.

Fixes issue #39. 

cc: @Johannestegner 