### PR TITLE
No KBFS

### DIFF
--- a/docker/entrypoint-generate.sh
+++ b/docker/entrypoint-generate.sh
@@ -8,7 +8,7 @@ chown -R keybase:keybase /mnt
 # Run everything else as the keybase user
 sudo -i -u keybase bash << EOF
 export "FORCE_WRITE=$FORCE_WRITE"
-nohup bash -c "run_keybase -g &"
+nohup bash -c "run_keybase -g -f &"
 sleep 3
 keybase oneshot --username $KEYBASE_USERNAME --paperkey "$KEYBASE_PAPERKEY"
 source docker/env.sh && bin/keybaseca generate

--- a/docker/entrypoint-server.sh
+++ b/docker/entrypoint-server.sh
@@ -7,7 +7,7 @@ chown -R keybase:keybase /mnt
 
 # Run everything else as the keybase user
 sudo -i -u keybase bash << EOF
-nohup bash -c "run_keybase -g &"
+nohup bash -c "run_keybase -g -f &"
 sleep 3
 keybase oneshot --username $KEYBASE_USERNAME --paperkey "$KEYBASE_PAPERKEY"
 source docker/env.sh && bin/keybaseca service


### PR DESCRIPTION
Added -f flag on invocation of the `run_keybase` startup script in the entrypoint files to tell keybase to not use KBFS. This removes the following error message:

> KBFS failed to FUSE mount at /home/keybase/.config/keybase/kbfs: fusermount: exit status 1

Ref to command line flag: https://github.com/keybase/client/blob/151162e6839373b1157c0c15bb874e6d32eb17fd/packaging/linux/run_keybase#L234