### PR TITLE
Verify pgp signatures on the downloaded deb file

### DIFF
--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -2,15 +2,22 @@
 # between this file and Dockerfile-kssh.
 FROM ubuntu:18.04
 
+# Dependencies
 RUN apt-get -qq update
-RUN apt-get -qq  install curl software-properties-common -y
+RUN apt-get -qq  install curl software-properties-common ca-certificates gnupg -y
 RUN useradd -ms /bin/bash keybase
 USER keybase
 WORKDIR /home/keybase
+
+# Download and verify the deb
+# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
-USER root
+RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
+RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it
+USER root
 RUN dpkg -i keybase_amd64.deb || true
 RUN apt-get install -fy
 USER keybase

--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -13,7 +13,9 @@ WORKDIR /home/keybase
 # Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it

--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -13,7 +13,7 @@ WORKDIR /home/keybase
 # Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -13,7 +13,9 @@ WORKDIR /home/keybase
 # Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -2,15 +2,22 @@
 # between this file and Dockerfile-ca.
 FROM ubuntu:18.04
 
+# Dependencies
 RUN apt-get -qq update
-RUN apt-get -qq  install curl software-properties-common -y
+RUN apt-get -qq  install curl software-properties-common ca-certificates gnupg -y
 RUN useradd -ms /bin/bash keybase
 USER keybase
 WORKDIR /home/keybase
+
+# Download and verify the deb
+# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
-USER root
+RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
+RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it
+USER root
 RUN dpkg -i keybase_amd64.deb || true
 RUN apt-get install -fy
 USER keybase

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -13,7 +13,7 @@ WORKDIR /home/keybase
 # Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it


### PR DESCRIPTION
Just as a bit of defense in depth so we verify the downloaded installer. 

cc: @Johannestegner 