### PR TITLE
Revert "Merge pull request #55 from keybase/david/docker-build-verify-pgp"

### DIFF
--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -2,24 +2,15 @@
 # between this file and Dockerfile-kssh.
 FROM ubuntu:18.04
 
-# Dependencies
 RUN apt-get -qq update
-RUN apt-get -qq  install curl software-properties-common ca-certificates gnupg -y
+RUN apt-get -qq  install curl software-properties-common -y
 RUN useradd -ms /bin/bash keybase
 USER keybase
 WORKDIR /home/keybase
-
-# Download and verify the deb
-# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
-RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
-RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
+USER root
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it
-USER root
 RUN dpkg -i keybase_amd64.deb || true
 RUN apt-get install -fy
 USER keybase

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -2,24 +2,15 @@
 # between this file and Dockerfile-ca.
 FROM ubuntu:18.04
 
-# Dependencies
 RUN apt-get -qq update
-RUN apt-get -qq  install curl software-properties-common ca-certificates gnupg -y
+RUN apt-get -qq  install curl software-properties-common -y
 RUN useradd -ms /bin/bash keybase
 USER keybase
 WORKDIR /home/keybase
-
-# Download and verify the deb
-# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
-RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
-RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
+USER root
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it
-USER root
 RUN dpkg -i keybase_amd64.deb || true
 RUN apt-get install -fy
 USER keybase


### PR DESCRIPTION
This reverts commit 79a7d866fe13f2f6cb2d30c866dd47cdec0acc67, reversing
changes made to a08fe3681bcddc88350a6426dc43e60824cf523a.

Some people are reporting that the gpg fails for them. It works locally and in CI but reverting for now. 

cc: @xgess Just merging this to fix for someone since it is just a revert