### PR TITLE
GPG Verify Keybase Installer v2

### DIFF
--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -2,15 +2,24 @@
 # between this file and Dockerfile-kssh.
 FROM ubuntu:18.04
 
+# Dependencies
 RUN apt-get -qq update
-RUN apt-get -qq  install curl software-properties-common -y
+RUN apt-get -qq  install curl software-properties-common ca-certificates gnupg -y
 RUN useradd -ms /bin/bash keybase
 USER keybase
 WORKDIR /home/keybase
+
+# Download and verify the deb
+# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
-USER root
+RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
+RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it
+USER root
 RUN dpkg -i keybase_amd64.deb || true
 RUN apt-get install -fy
 USER keybase

--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -13,9 +13,19 @@ WORKDIR /home/keybase
 # Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+# GPG has no easy way of getting the ID associated with a key, so we do this :(
+# This line will error if the fingerprint of the key in the file does not match
+# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
+# Note that we do it this way rather than via the key servers since pulling from the
+# key servers caused a flakey build
+RUN gpg --with-colons --fingerprint $( \
+        curl -sSL https://keybase.io/docs/server_security/code_signing_key.asc | \
+        gpg --import 2>&1 | \
+        grep -v created | \
+        head -n 1 | \
+        cut -d ' ' -f 3 | \
+        cut -d ':' -f 1 \
+    ) | grep fpr | cut -d ':' -f 10 | grep 222B85B0F90BE2D24CFEB93F47484E50656D16C7
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it

--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -13,19 +13,13 @@ WORKDIR /home/keybase
 # Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-# GPG has no easy way of getting the ID associated with a key, so we do this :(
-# This line will error if the fingerprint of the key in the file does not match
-# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
-# Note that we do it this way rather than via the key servers since pulling from the
-# key servers caused a flakey build
-RUN gpg --with-colons --fingerprint $( \
-        curl -sSL https://keybase.io/docs/server_security/code_signing_key.asc | \
-        gpg --import 2>&1 | \
-        grep -v created | \
-        head -n 1 | \
-        cut -d ' ' -f 3 | \
-        cut -d ':' -f 1 \
-    ) | grep fpr | cut -d ':' -f 10 | grep 222B85B0F90BE2D24CFEB93F47484E50656D16C7
+# Import our gpg key from our website. Pulling from key servers caused a flakey build so
+# we get the key from the Keybase website instead.
+RUN curl -sSL https://keybase.io/docs/server_security/code_signing_key.asc | gpg --import
+# This line will error if the fingerprint of the key in the file does not match the
+# known fingerprint of the our PGP key
+RUN gpg --fingerprint 222B85B0F90BE2D24CFEB93F47484E50656D16C7
+# And then verify the signature now that we have the key
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it

--- a/integrationTest.sh
+++ b/integrationTest.sh
@@ -17,7 +17,6 @@ if [ -z "$CIRCLECI" ]; then
   cd ../
 fi
 
-
 # Ensure we have the correct environment variables
 if [[ -f "tests/env.sh" ]]; then
   echo "env.sh already exists, skipping configuring new accounts..."

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -10,12 +10,21 @@ USER keybase
 WORKDIR /home/keybase
 
 # Download and verify the deb
-# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+# GPG has no easy way of getting the ID associated with a key, so we do this :(
+# This line will error if the fingerprint of the key in the file does not match
+# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
+# Note that we do it this way rather than via the key servers since pulling from the
+# key servers caused a flakey build
+RUN gpg --with-colons --fingerprint $( \
+        curl -sSL https://keybase.io/docs/server_security/code_signing_key.asc | \
+        gpg --import 2>&1 | \
+        grep -v created | \
+        head -n 1 | \
+        cut -d ' ' -f 3 | \
+        cut -d ':' -f 1 \
+    ) | grep fpr | cut -d ':' -f 10 | grep 222B85B0F90BE2D24CFEB93F47484E50656D16C7
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -2,15 +2,24 @@
 # between this file and Dockerfile-ca.
 FROM ubuntu:18.04
 
+# Dependencies
 RUN apt-get -qq update
-RUN apt-get -qq  install curl software-properties-common -y
+RUN apt-get -qq  install curl software-properties-common ca-certificates gnupg -y
 RUN useradd -ms /bin/bash keybase
 USER keybase
 WORKDIR /home/keybase
+
+# Download and verify the deb
+# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
-USER root
+RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
+RUN gpg --keyserver pgp.mit.edu --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "222B85B0F90BE2D24CFEB93F47484E50656D16C7"
+RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it
+USER root
 RUN dpkg -i keybase_amd64.deb || true
 RUN apt-get install -fy
 USER keybase

--- a/tests/Dockerfile-kssh
+++ b/tests/Dockerfile-kssh
@@ -12,19 +12,13 @@ WORKDIR /home/keybase
 # Download and verify the deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb
 RUN curl --remote-name https://prerelease.keybase.io/keybase_amd64.deb.sig
-# GPG has no easy way of getting the ID associated with a key, so we do this :(
-# This line will error if the fingerprint of the key in the file does not match
-# Key fingerprint from https://keybase.io/docs/server_security/our_code_signing_key
-# Note that we do it this way rather than via the key servers since pulling from the
-# key servers caused a flakey build
-RUN gpg --with-colons --fingerprint $( \
-        curl -sSL https://keybase.io/docs/server_security/code_signing_key.asc | \
-        gpg --import 2>&1 | \
-        grep -v created | \
-        head -n 1 | \
-        cut -d ' ' -f 3 | \
-        cut -d ':' -f 1 \
-    ) | grep fpr | cut -d ':' -f 10 | grep 222B85B0F90BE2D24CFEB93F47484E50656D16C7
+# Import our gpg key from our website. Pulling from key servers caused a flakey build so
+# we get the key from the Keybase website instead.
+RUN curl -sSL https://keybase.io/docs/server_security/code_signing_key.asc | gpg --import
+# This line will error if the fingerprint of the key in the file does not match the
+# known fingerprint of the our PGP key
+RUN gpg --fingerprint 222B85B0F90BE2D24CFEB93F47484E50656D16C7
+# And then verify the signature now that we have the key
 RUN gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
 
 # Silence the error from dpkg about failing to configure keybase since `apt-get install -f` fixes it


### PR DESCRIPTION
This fixes gpg signature verification to not rely on the key servers (without just blindly trusting the TLS connection to Keybase). The PGP key is downloaded from keybase and it is verified that the key fingerprint matches the correct fingerprint. Relying on the key servers caused flakey builds in some cases.

Sadly, gpg does not provide any easy way of asserting that the imported fingerprint matches, so I had to resort to some bash fu in order to get this to work properly. Basically I'm downloading the key, parsing the output from gpg to get the short key ID, then using gpg to get the fingerprint associated with the short key ID, and checking that the fingerprint matches (via grep). 
