### PR TITLE
fix issues with env vars and entrypoint

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,7 +28,7 @@ generate: env-file-exists build
 # Start the CA chatbot in the background
 serve: env-file-exists ca-key-exists
 	docker run -d --restart unless-stopped --env-file ./env.list -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest ./entrypoint-server.sh
-	@echo "Started CA bot service in the background... Use `docker ps` and `docker logs` to monitor it"
+	@echo 'Started CA bot service in the background... Use `docker ps` and `docker logs` to monitor it'
 
 # Stop the service
 stop:

--- a/docker/entrypoint-generate.sh
+++ b/docker/entrypoint-generate.sh
@@ -8,6 +8,9 @@ chown -R keybase:keybase /mnt
 # Run everything else as the keybase user
 sudo -i -u keybase bash << EOF
 export "FORCE_WRITE=$FORCE_WRITE"
+export "TEAMS=$TEAMS"
+export "KEYBASE_USERNAME=$KEYBASE_USERNAME"
+export "KEYBASE_PAPERKEY=$KEYBASE_PAPERKEY"
 nohup bash -c "KEYBASE_RUN_MODE=prod kbfsfuse /keybase | grep -v 'ERROR Mounting the filesystem failed' &"
 sleep 3
 keybase oneshot

--- a/docker/entrypoint-server.sh
+++ b/docker/entrypoint-server.sh
@@ -7,6 +7,9 @@ chown -R keybase:keybase /mnt
 
 # Run everything else as the keybase user
 sudo -i -u keybase bash << EOF
+export "TEAMS=$TEAMS"
+export "KEYBASE_USERNAME=$KEYBASE_USERNAME"
+export "KEYBASE_PAPERKEY=$KEYBASE_PAPERKEY"
 nohup bash -c "KEYBASE_RUN_MODE=prod kbfsfuse /keybase | grep -v 'ERROR Mounting the filesystem failed' &"
 sleep 3
 keybase oneshot

--- a/docker/env.list.example
+++ b/docker/env.list.example
@@ -1,7 +1,13 @@
 # List the subteams here separated by commas (eg "teamname.ssh.production,teamname.ssh.staging") that you
 # wish to use to grant SSH access
-TEAMS="teamname.ssh.staging,teamname.ssh.production,..."
+TEAMS=teamname.ssh.staging,teamname.ssh.production
 
 # Login info for the chat bot
-KEYBASE_USERNAME="username_of_ca_bot"
-KEYBASE_PAPERKEY="paper key for the ca bot"
+KEYBASE_USERNAME=username_of_ca_bot
+KEYBASE_PAPERKEY=paper key for the ca bot
+
+# DO NOT QUOTE VARIABLE VALUES
+#
+# These variables will be single quoted when loaded into the container. If you quote them here, those
+# quotes will become part of the variable value.
+


### PR DESCRIPTION
these are fixes for #78 

i also single-quoted the echo line in `make serve` that uses backticks, because those sections were interpreted by the shell as _actual_ docker commands and screwed up the output.


