### PR TITLE
Makefile add support for dockerhub image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,13 +5,23 @@ else
 FORCE_WRITE := false
 endif
 
+
+
+
+
 SHELL := /bin/bash
 
 .PHONY: build generate serve clean reset-permissions confirm-clean env-file-exists ca-key-exists
 
 # Build a new docker image for the CA bot
 build: reset-permissions
+ifdef DOCKER_IMAGE
+	docker pull $(DOCKER_IMAGE)
+	docker tag $(DOCKER_IMAGE) ca
+else
 	docker build -t ca -f Dockerfile-ca ..
+endif
+
 
 # Generate a new CA key
 generate: env-file-exists build

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,10 +5,6 @@ else
 FORCE_WRITE := false
 endif
 
-
-
-
-
 SHELL := /bin/bash
 
 .PHONY: build generate serve clean reset-permissions confirm-clean env-file-exists ca-key-exists


### PR DESCRIPTION
Rather than having to build the docker image locally, setting an optional env var DOCKER_IMAGE will instead pull the image from dockerhub e.g.

```
export DOCKER_IMAGE=jbeeson/bot-certca
make generate
```
...