### PR TITLE
add  to actually delete all config files when the service is stopped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ keybaseca.config
 nohup.out
 env.list
 __pycache__
+**/.mypy_cache/
+tests/env.sh
 
 # sphinx generated files:
 _build

--- a/docker/Dockerfile-ca
+++ b/docker/Dockerfile-ca
@@ -44,6 +44,7 @@ COPY --from=builder --chown=keybase:keybase /bot-sshca/bin/keybaseca bin/
 # copy in entrypoint scripts
 COPY --chown=keybase:keybase ./docker/entrypoint-generate.sh ./
 COPY --chown=keybase:keybase ./docker/entrypoint-server.sh ./
+COPY --chown=keybase:keybase ./docker/entrypoint-cleanup.sh ./
 
 # Run container as root but only to be able to chown the Docker bind-mount, 
 # then immediatetly step down to the keybase user via sudo in the entrypoint scripts

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,7 +21,7 @@ endif
 
 # Generate a new CA key
 generate: env-file-exists build
-	docker run -e FORCE_WRITE=$(FORCE_WRITE) --env-file ./env.list -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest ./entrypoint-generate.sh
+	docker run --init -e FORCE_WRITE=$(FORCE_WRITE) --env-file ./env.list -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest ./entrypoint-generate.sh
 	@echo -e "\nRun these commands on each server that you wish to use with the CA chatbot\n"
 	@echo "useradd developer && mkdir -p /home/developer && chown developer:developer /home/developer  # The user that will be used for non-root logins"
 	@echo "echo \"`cat $(CURDIR)/example-keybaseca-volume/keybase-ca-key.pub`\" > /etc/ssh/ca.pub"
@@ -33,17 +33,21 @@ generate: env-file-exists build
 
 # Start the CA chatbot in the background
 serve: env-file-exists ca-key-exists
-	docker run -d --restart unless-stopped --env-file ./env.list -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest ./entrypoint-server.sh
+	docker run -d --init --restart unless-stopped --env-file ./env.list -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest ./entrypoint-server.sh
 	@echo 'Started CA bot service in the background... Use `docker ps` and `docker logs` to monitor it'
 
 # Stop the service
-stop:
+stop: clean-kssh
 	docker kill `docker ps -q --filter ancestor=ca`
 
 # Restart the service (useful if you updated env.list)
 restart: stop serve
 
-# Wipe all data
+# Delete all kssh config files
+clean-kssh: env-file-exists
+	docker run --init -e FORCE_WRITE=$(FORCE_WRITE) --env-file ./env.list -v $(CURDIR)/example-keybaseca-volume:/mnt:rw ca:latest ./entrypoint-cleanup.sh
+
+# Delete all CA data
 clean: confirm-clean reset-permissions
 	@# Sudo since it is likely owned by another use since it was written from a docker container
 	sudo rm -rf example-keybaseca-volume/keybaseca*

--- a/docker/entrypoint-cleanup.sh
+++ b/docker/entrypoint-cleanup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# chown as root
+chown -R keybase:keybase /mnt
+
+# Run everything else as the keybase user
+sudo -i -u keybase bash << EOF
+export "FORCE_WRITE=$FORCE_WRITE"
+export "KEYBASE_USERNAME=$KEYBASE_USERNAME"
+export "KEYBASE_PAPERKEY=$KEYBASE_PAPERKEY"
+nohup bash -c "KEYBASE_RUN_MODE=prod kbfsfuse /keybase | grep -v 'ERROR Mounting the filesystem failed' &"
+sleep ${KEYBASE_TIMEOUT:-5}
+keybase oneshot
+bin/keybaseca --wipe-all-configs
+sleep ${KEYBASE_TIMEOUT:-5}
+EOF


### PR DESCRIPTION
I don't know if this ever worked, but my kssh config files were not getting deleted on `docker kill` of the keybaseca container. Issue #86 mentions the same problem. (Note my files do get properly deleted if I'm in the container and only kill the keybaseca process.)

This is because `docker kill` sends a SIGKILL only to the process with pid1, and that process wasn't forwarding the signal to the keybaseca process. Adding `--init` to `docker run` makes it such that an init process based on tini is run as pid 1, that will properly reap zombie processes. But the problem here is that even if we are able to properly propagate the signal to keybaseca, keybaseca needs kbfsfuse to stay alive long enough to actually delete the config files. So at this point...I decided to try another approach of just starting another docker container to delete all config files, before killing all ca-related containers.

`make clean-kssh` will delete all config files that the CA Keybase account can find. This will only mess you up if for some reason, you have another CA bot simultaneously running that is listening on and signing keys for the same teams -- this seems really unlikely, and if you are in this situation, you can just restart your other CA bot to rewrite the kssh files.