### PR TITLE
Ignore implicit memberships in Requester.getAllTeams

### DIFF
--- a/src/keybaseca/bot/bot.go
+++ b/src/keybaseca/bot/bot.go
@@ -252,14 +252,7 @@ func (b *Bot) DeleteAllClientConfigs() error {
 }
 
 func (b *Bot) getAllTeams() (teams []string, err error) {
-	memberships, err := b.api.ListUserMemberships(b.api.GetUsername())
-	if err != nil {
-		return teams, err
-	}
-	for _, m := range memberships {
-		teams = append(teams, m.FqName)
-	}
-	return teams, nil
+	return shared.GetAllTeams(b.api)
 }
 
 // LogError logs the given error to Keybase chat and to the configured log file. Used so

--- a/src/keybaseca/sshutils/sshutils.go
+++ b/src/keybaseca/sshutils/sshutils.go
@@ -151,9 +151,10 @@ func SignKey(caKeyLocation, keyID, principals, expiration, publicKey string) (si
 	return string(signatureBytes), nil
 }
 
-// Get the principals that should be placed in the signed certificate.
-// Note that this function is a security boundary since if it was bypassed an
-// attacker would be able to provision SSH keys for environments that they should not have access to.
+// Get the principals that should be placed in the signed certificate. Note
+// that this function is a security boundary since if it was bypassed an
+// attacker would be able to provision SSH keys for environments that they
+// should not have access to.
 func getPrincipals(conf config.Config, sr shared.SignatureRequest) (string, error) {
 	// Start by getting the list of teams the user is in
 	api, err := botwrapper.GetKBChat(conf.GetKeybaseHomeDir(), conf.GetKeybasePaperKey(), conf.GetKeybaseUsername(), conf.GetKeybaseTimeout())
@@ -165,11 +166,13 @@ func getPrincipals(conf config.Config, sr shared.SignatureRequest) (string, erro
 		return "", fmt.Errorf("failed to retrieve the list of teams the user is in: %v", err)
 	}
 
-	// Maps from a team to whether or not the user is in the current team (with writer, admin, or owner permissions)
+	// Maps from a team to whether or not the user is in the current team (with
+	// writer, admin, or owner permissions)
 	teamToMembership := make(map[string]bool)
 	for _, result := range results {
-		if result.Role != 0 {
-			// result.Role == 0 means they are an impicit admin in the team and are not actually a member
+		// Check if the user is actually in the team, and not a restricted bot
+		// or implicit admin.
+		if shared.CanRoleReadTeam(result.Role) {
 			teamToMembership[result.FqName] = true
 		}
 	}

--- a/src/kssh/requester.go
+++ b/src/kssh/requester.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/keybase/bot-sshca/src/shared"
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
-	"github.com/keybase/go-keybase-chat-bot/kbchat/types/keybase1"
 )
 
 type Requester struct {
@@ -89,17 +88,7 @@ func (r *Requester) LoadConfigForBot(botName string) (Config, error) {
 }
 
 func (r *Requester) getAllTeams() (teams []string, err error) {
-	// TODO: dedup with same method in keybaseca/bot
-	memberships, err := r.api.ListUserMemberships(r.api.GetUsername())
-	if err != nil {
-		return teams, err
-	}
-	for _, m := range memberships {
-		if m.Role != keybase1.TeamRole_NONE {
-			teams = append(teams, m.FqName)
-		}
-	}
-	return teams, nil
+	return shared.GetAllTeams(r.api)
 }
 
 // Get a signed SSH key from interacting with the CA chatbot

--- a/src/kssh/requester.go
+++ b/src/kssh/requester.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keybase/bot-sshca/src/shared"
 	"github.com/keybase/go-keybase-chat-bot/kbchat"
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/keybase1"
 )
 
 type Requester struct {
@@ -94,7 +95,9 @@ func (r *Requester) getAllTeams() (teams []string, err error) {
 		return teams, err
 	}
 	for _, m := range memberships {
-		teams = append(teams, m.FqName)
+		if m.Role != keybase1.TeamRole_NONE {
+			teams = append(teams, m.FqName)
+		}
 	}
 	return teams, nil
 }

--- a/src/shared/teams.go
+++ b/src/shared/teams.go
@@ -24,7 +24,6 @@ func CanRoleReadTeam(role keybase1.TeamRole) bool {
 // GetAllTeams makes an API call and returns list of team names readable for
 // current user.
 func GetAllTeams(api *kbchat.API) (teams []string, err error) {
-	// TODO: dedup with same method in keybaseca/bot
 	memberships, err := api.ListUserMemberships(api.GetUsername())
 	if err != nil {
 		return teams, err

--- a/src/shared/teams.go
+++ b/src/shared/teams.go
@@ -1,0 +1,38 @@
+package shared
+
+import (
+	"github.com/keybase/go-keybase-chat-bot/kbchat"
+	"github.com/keybase/go-keybase-chat-bot/kbchat/types/keybase1"
+)
+
+// CanRoleReadTeam checks if given role can access team data. User has to be an
+// actual team member (not implicit admin) to be able to access data, and
+// cannot be a RESTRICTED BOT.
+func CanRoleReadTeam(role keybase1.TeamRole) bool {
+	switch role {
+	case keybase1.TeamRole_READER,
+		keybase1.TeamRole_WRITER,
+		keybase1.TeamRole_ADMIN,
+		keybase1.TeamRole_OWNER,
+		keybase1.TeamRole_BOT:
+		return true
+	default:
+		return false
+	}
+}
+
+// GetAllTeams makes an API call and returns list of team names readable for
+// current user.
+func GetAllTeams(api *kbchat.API) (teams []string, err error) {
+	// TODO: dedup with same method in keybaseca/bot
+	memberships, err := api.ListUserMemberships(api.GetUsername())
+	if err != nil {
+		return teams, err
+	}
+	for _, m := range memberships {
+		if CanRoleReadTeam(m.Role) {
+			teams = append(teams, m.FqName)
+		}
+	}
+	return teams, nil
+}


### PR DESCRIPTION
When current user is an implicit admin in any team, loading kssh configs from Keybase KV store will fail for that team, failing the entire process. KV store is not available unless the user is an explicit member. This PR changes `Requester.getAllTeams` to skip teams where user is not an explicit member.